### PR TITLE
Updated source files to support generic paths

### DIFF
--- a/src/Infrastructure/Client/Protomolecule.ts
+++ b/src/Infrastructure/Client/Protomolecule.ts
@@ -59,7 +59,7 @@ export default class Protomolecule extends Client {
 			console.log('No token present');
 
 		try {
-			this.commandHandler.init(Path.join(__dirname, '..\\..\\Commands'));
+			this.commandHandler.init(Path.join(__dirname, '..', '..', 'Commands'));
 		} catch (error) {
 			console.log('Unable to load commands');
 		}

--- a/src/Infrastructure/Database/Inserts/Expanse/Books.ts
+++ b/src/Infrastructure/Database/Inserts/Expanse/Books.ts
@@ -7,7 +7,7 @@ import { BookData } from '../../../Interfaces/Expanse';
 
 export async function insertBooks(connection: Connection): Promise<void> {
 	const bookDataString: string[] = fs.readFileSync(
-		Path.resolve(__dirname, '..\\..\\Data\\Expanse\\books.txt'), 'utf8'
+		Path.resolve(__dirname, Path.join('..', '..', 'Data', 'Expanse', 'books.txt')), 'utf8'
 	).split('\n');
 
 	const bookRepo: Repository<Book> = connection.getRepository(Book);

--- a/src/Infrastructure/Database/Inserts/Expanse/Characters.ts
+++ b/src/Infrastructure/Database/Inserts/Expanse/Characters.ts
@@ -7,7 +7,7 @@ import { CharacterData } from '../../../Interfaces/Expanse';
 
 export async function insertCharacters(connection: Connection): Promise<void> {
 	const characterDataString: string[] = fs.readFileSync(
-		Path.resolve(__dirname, '..\\..\\Data\\Expanse\\characters.txt'), 'utf8'
+		Path.resolve(__dirname, Path.join('..', '..', 'Data', 'Expanse', 'characters.txt')), 'utf8'
 	).split('\n');
 
 	const characterRepo: Repository<Character> = connection.getRepository(Character);

--- a/src/Infrastructure/Database/Inserts/Expanse/Quotes.ts
+++ b/src/Infrastructure/Database/Inserts/Expanse/Quotes.ts
@@ -7,7 +7,7 @@ import { QuoteData } from '../../../Interfaces/Expanse';
 
 export function insertQuotes(connection: Connection): void {
 	const quoteDataString: string = fs.readFileSync(
-		Path.join(__dirname, '..\\..\\Data\\Expanse\\Quotes\\avasarala.json') as string, 'utf8'
+		Path.join(__dirname, Path.join('..', '..', 'Data', 'Expanse', 'Quotes', 'avasarala.json')) as string, 'utf8'
 	);
 
 	const quoteData: QuoteData[] = JSON.parse(quoteDataString);

--- a/src/Infrastructure/Database/Inserts/System/ReactionCategories.ts
+++ b/src/Infrastructure/Database/Inserts/System/ReactionCategories.ts
@@ -7,7 +7,7 @@ import { ReactionCategoryData } from '../../../Interfaces/System';
 
 export async function insertReactionCategories(connection: Connection): Promise<void> {
 	const reactionCategoryString: string[] = fs.readFileSync(
-		Path.resolve(__dirname, '..\\..\\Data\\System\\Reactions\\reactionCategories.txt'), 'utf8'
+		Path.resolve(__dirname, Path.join('..', '..', 'Data', 'System', 'Reactions', 'reactionCategories.txt')), 'utf8'
 	).split('\n');
 
 	const reactionCategoryRepo: Repository<ReactionCategory> = connection.getRepository(ReactionCategory);


### PR DESCRIPTION
Changed all the hardcoded paths of the format '..\\..\\folder\\file.txt'
to ts Path.join('..', '..', 'folder', 'file.txt') function to support
building/running on multiple platforms (Linux, Windows, MacOS).  Located
issues with a `grep -rH '\\\\' src` command.