### PR TITLE
Update command infrastructure in a few ways:

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Put the following in a file named config.json5:
 	"commandPrefix": ".",
 	"statusType": "WATCHING",
 	"statusText": "you sleep...",
+	"unlimitedRoles": [ "The Rocinante", "Moderation Team" ],
 	// A map from servers to reaction channels
 	"welcomeChannels": {
         "{SERVER_ID}": "{CHANNEL_ID}",
@@ -56,6 +57,7 @@ npm run dev
 	- `commandPrefix` - Specify the command prefix.
 	- `statusType` - What status is the bot?
 	- `statusText` - Accompanying text for the bot status.
+	- `unlimitedRoles` - Names of roles that aren't affected by rate limiting.
 	- `welcomeChannels` - A mapping of guild IDs to welcome channels. Protomolecule will use these to automatically create a welcome message and messages to react to.
 
 After running these, you will also need to set up any guilds in welcomeChannels with the appropriate emoji and roles.

--- a/bin/protomolecule.js
+++ b/bin/protomolecule.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../dist/index').infect();
+require('../dist/cmd');

--- a/config.example.json5
+++ b/config.example.json5
@@ -4,6 +4,7 @@
 	"commandPrefix": ".",
 	"statusType": "WATCHING",
 	"statusText": "you sleep...",
+	"unlimitedRoles": [ 'The Rocinante', 'Moderation Team' ],
 	// A map from servers to reaction channels
 	"welcomeChannels": {
         "1234": "1234",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"code:build": "tsc -p ./tsconfig.json",
 		"docs:build": "typedoc",
 		"db:seed": "ts-node ./src/Infrastructure/Database/Inserts/index.ts",
-		"dev": "ts-node ./src/index.ts --config config.json5",
+		"dev": "ts-node ./src/cmd.ts --config config.json5",
 		"prepare": "npm run code:build"
 	},
 	"dependencies": {

--- a/src/Commands/Nerd/APoD.ts
+++ b/src/Commands/Nerd/APoD.ts
@@ -21,7 +21,7 @@ export default class APoD extends Command {
 			usage: '<prefix>apod <Argument>?',
 			group: [ 'nerd' ],
 			roles: [],
-			commandsPerSecond: 0.005,
+			commandsPerMinute: 0.5,
 			commandSurgeMax: 1.5
 		});
 	}

--- a/src/Commands/Nerd/APoD.ts
+++ b/src/Commands/Nerd/APoD.ts
@@ -12,7 +12,7 @@ import { Nerd } from '../../Utils';
  *
  * @category Commands: Nerd
  */
-export class APoD extends Command {
+export default class APoD extends Command {
 	public constructor() {
 		super({
 			name: 'APoD',
@@ -21,9 +21,8 @@ export class APoD extends Command {
 			usage: '<prefix>apod <Argument>?',
 			group: [ 'nerd' ],
 			roles: [],
-			rolesDebitTickets: 7500,
-			unlimitedRoles: [ 'The Rocinante', 'Moderation Team' ],
-			unlimitedRolesDebitTickets: 0
+			commandsPerSecond: 0.005,
+			commandSurgeMax: 1.5
 		});
 	}
 

--- a/src/Commands/Nerd/Avasarala.ts
+++ b/src/Commands/Nerd/Avasarala.ts
@@ -1,0 +1,106 @@
+'use strict';
+import { Command } from '../../Infrastructure/System/Command';
+import { Message, MessageEmbed } from 'discord.js';
+
+const guildIconURL : string = 'https://cdn.discordapp.com/icons/288472445822959618/2f192af7943f8401fec6b2a2455eb16a.jpg';
+
+// avasarala, images and quotes supplied by /u/it-reaches-out
+const avasaralaImages : string[] = [
+	'http://i.imgur.com/gLAavTM.png',
+	'http://i.imgur.com/BLW3xwc.png',
+	'http://i.imgur.com/9naUBis.png',
+	'http://i.imgur.com/XaNMSo1.png',
+	'http://i.imgur.com/i8oaYj9.png',
+	'http://i.imgur.com/gF4kme3.png',
+	'http://i.imgur.com/FrZHD72.png',
+	'http://i.imgur.com/l9B8QNj.png',
+	'http://i.imgur.com/a3HUir3.png',
+	'http://i.imgur.com/270wrQm.png'
+];
+const avasaralaQuotes : string[] = [
+	'Realizing you\'ve got shit on your fingers is the first step to washing your hands.',
+	'No one likes a smart-ass.',
+	'Always good to have a penis in uniform in the room.',
+	'God save us all from good-looking men.',
+	'As long as we keep comparing dicks, no one will shoot.',
+	'You want a little ass-play, that\'s your business.',
+	'Space is too fucking big.',
+	'My life has become a single, ongoing revelation that I haven\'t been cynical enough.',
+	'No one ever tries reconnecting with an ex-wife without seeming like an asshole.',
+	'I know everything. This is a fucking test.',
+	'Try not to put your dick in this. It\'s fucked enough already.',
+	'When I said don\'t hurry, I didn\'t mean you should take the whole fucking day off.',
+	'Stop busting my balls. I\'m out of tea.',
+	'Meow meow cry meow meow. That\'s all I heard you say.',
+	'I swear to God I\'ll have you turning tricks out of a prefab shed on the side of the highway.',
+	'You do good work. Someday you might get a real job.',
+	'Shut the fuck up now, dear, the grown-up is talking.',
+	'Sleep? Yes, I remember that vaguely.',
+	'Of course I want you to call me on my bullshit. That\'s what I pay you for.',
+	'I don\'t give a fuck whose birthday it is, you make this happen before my meeting ' +
+    'is over or I\'ll have your nuts as paperweights.',
+	'This was a cock-up from the start.',
+	'Just assume I know what I\'m doing, and that when I ask you to do the impossible, it\'s ' +
+	'because even your failure helps our cause somehow.',
+	'I have violated your privacy in ways you can\'t imagine.',
+	'I do everything, and every second I talk to you costs ten thousand dollars.',
+	'Would you all please shut the fuck up?',
+	'I know why you kept me out of this, and I think you\'re a fucking moron for it, but put it ' +
+	'aside. It doesn\'t matter now. Just do not pull that fucking trigger.',
+	'This is just an excuse to wave their cocks at each other.',
+	'He is walking around his words like they\'ve got poisoned spikes on them.',
+	'I have crates of anti-herpes drugs that are more legitimately UN Navy than you are.',
+	'I\'m sorry, did I seem to give a fuck that this is your ship? If I did, really, I was just being polite.',
+	'We\'re off the clock now. You can stop blowing smoke up my ass.',
+	'By the time he understands what we were really after, it\'ll be too late for him to do anything' +
+	' but hold his dick and cry.',
+	'No one starts a war unless I say they can.',
+	'I\'m not someone you want to fuck with.',
+	'Call me that again and I\'ll have an officer beat you gently with a cattle prod.',
+	'Most men who\'ve spent so much time with me seem convinced their cocks will fall off if they can\'t ' +
+	'get away from me.',
+	'Life is too short for this shit.',
+	'So we\'re all fucking morons. Fine.',
+	'This sucks donkey balls.',
+	'Sounds like piss. I\'ll take it.',
+	'You\'re an asshole and nobody loves you.',
+	'Screw it, I need a drink.',
+	'That man\'s asshole must be tight enough right now to bend space.',
+	'He can\'t find his cock with both hands unless there\'s someone there to point him at it.',
+	'He\'s a fucking busybody and he should stop putting his fingers in my shit.',
+	'I don\'t mean that they all fuck men. I mean they\'re all men, the fuckers.',
+	'How the fuck do you keep your hair like that? I look like a hedgehog\'s been humping my skull.'
+];
+
+export default class Avasarala extends Command {
+	public constructor() {
+		super({
+			name: 'Avasarala',
+			command: [ 'ca' ],
+			description: 'A Random Quote from Chrisjen Avasarala',
+			usage: '<prefix>ca',
+			group: [ 'nerd' ],
+			roles: [],
+			commandsPerSecond: 0.1,
+			commandSurgeMax: 2.0
+		});
+	}
+
+	public async execute(message: Message, _: string[]): Promise<void> {
+		// variable declaration
+		const quote: string = avasaralaQuotes[Math.floor(Math.random() * avasaralaQuotes.length)];
+		const image: string = avasaralaImages[Math.floor(Math.random() * avasaralaImages.length)];
+
+		// build the quote
+		const embed: MessageEmbed = new MessageEmbed;
+		embed
+			.setColor(0x206694)
+			.setAuthor('Chrisjen Avasarala says...', guildIconURL)
+			.setThumbnail(image)
+			.addField('\u200b', `"${ quote }"`, false)
+			.setFooter('/u/it-reaches-out');
+
+		// send the quote
+		await message.channel.send(embed);
+	}
+}

--- a/src/Commands/Nerd/Avasarala.ts
+++ b/src/Commands/Nerd/Avasarala.ts
@@ -81,7 +81,7 @@ export default class Avasarala extends Command {
 			usage: '<prefix>ca',
 			group: [ 'nerd' ],
 			roles: [],
-			commandsPerSecond: 0.1,
+			commandsPerMinute: 5,
 			commandSurgeMax: 2.0
 		});
 	}

--- a/src/Commands/Nerd/XKCD.ts
+++ b/src/Commands/Nerd/XKCD.ts
@@ -23,7 +23,7 @@ export default class XKCD extends Command {
 			usage: '<prefix>xkcd <Argument>?',
 			group: [ 'nerd' ],
 			roles: [],
-			commandsPerSecond: 0.005,
+			commandsPerMinute: 0.5,
 			commandSurgeMax: 1.5
 		});
 	}

--- a/src/Commands/Nerd/XKCD.ts
+++ b/src/Commands/Nerd/XKCD.ts
@@ -14,7 +14,7 @@ import { Nerd } from '../../Utils';
  *
  * @category Commands: Nerd
  */
-export class XKCD extends Command {
+export default class XKCD extends Command {
 	public constructor() {
 		super({
 			name: 'XKCD',
@@ -23,17 +23,17 @@ export class XKCD extends Command {
 			usage: '<prefix>xkcd <Argument>?',
 			group: [ 'nerd' ],
 			roles: [],
-			rolesDebitTickets: 7500,
-			unlimitedRoles: [ 'The Rocinante', 'Moderation Team' ],
-			unlimitedRolesDebitTickets: 0
+			commandsPerSecond: 0.005,
+			commandSurgeMax: 1.5
 		});
 	}
 
 	public async execute(message: Message, args: string[]): Promise<void> {
 		let isRandom: boolean | undefined;
 
-		if (args[0])
+		if (args[0]) {
 			isRandom = args[0] === 'r';
+		}
 
 		const comicNumber: number | undefined =
 			args[0] && Nerd.isNumerical(args[0]) ? Number(args[0]) : undefined;

--- a/src/Infrastructure/Client/Protomolecule.ts
+++ b/src/Infrastructure/Client/Protomolecule.ts
@@ -2,8 +2,9 @@ import { ActivityType, Client, ClientOptions, Collection } from 'discord.js';
 import { Command } from '../System/Command';
 import { CommandHandler, EventHandler, RoleHandler } from '../Handlers';
 import { configDiscordClient } from './Config';
-import { APoD } from '../../Commands/Nerd/APoD';
-import { XKCD } from '../../Commands/Nerd/XKCD';
+import APoD from '../../Commands/Nerd/APoD';
+import XKCD from '../../Commands/Nerd/XKCD';
+import Avasarala from '../../Commands/Nerd/Avasarala';
 
 /**
  * ## Protomolecule
@@ -76,7 +77,7 @@ export default class Protomolecule extends Client {
 		}
 
 		try {
-			this.commandHandler.init([ APoD, XKCD ]);
+			this.commandHandler.init([ APoD, XKCD, Avasarala ]);
 		} catch (error) {
 			console.log('Unable to load commands');
 		}

--- a/src/Infrastructure/Client/Protomolecule.ts
+++ b/src/Infrastructure/Client/Protomolecule.ts
@@ -36,7 +36,7 @@ export default class Protomolecule extends Client {
 		this.statusText = configDiscordClient.statusText;
 
 		this.eventHandler = new EventHandler(this);
-		this.commandHandler = new CommandHandler(this);
+		this.commandHandler = new CommandHandler(this, configDiscordClient.unlimitedRoles);
 		this.roleManager = new RoleHandler(this, configDiscordClient.welcomeChannels);
 
 		this.commands = new Collection;

--- a/src/Infrastructure/Handlers/CommandHandler.ts
+++ b/src/Infrastructure/Handlers/CommandHandler.ts
@@ -9,10 +9,12 @@ import RateLimiter from '../Managers/RateLimiter';
 export class CommandHandler {
 	private readonly client: Protomolecule;
 	private readonly limiters: Record<string, RateLimiter>;
+	private readonly unlimitedRoles: string[];
 
-	public constructor(proto: Protomolecule) {
+	public constructor(proto: Protomolecule, unlimitedRoles: string[]) {
 		this.limiters = {};
 		this.client = proto;
+		this.unlimitedRoles = unlimitedRoles;
 	}
 
 	public init(commands: (new () => Command)[]): void {
@@ -69,7 +71,7 @@ export class CommandHandler {
 			const commandInstance: Command = new commandClass;
 
 			this.limiters[commandInstance.name] = new RateLimiter(1000,
-				commandInstance.commandsPerSecond,
+				commandInstance.commandsPerMinute / 60,
 				commandInstance.commandSurgeMax);
 			for (const cmd in commandInstance.command) {
 				if ({}.hasOwnProperty.call(commandInstance.command, cmd)) {
@@ -92,7 +94,7 @@ export class CommandHandler {
 	}
 
 	private hasUnlimitedRoles(member: GuildMember): boolean {
-		if (member.roles.cache.some(role => [ 'The Rocinante', 'Moderation Team' ].includes(role.name))) {
+		if (member.roles.cache.some(role => this.unlimitedRoles.includes(role.name))) {
 			return true;
 		}
 		return false;

--- a/src/Infrastructure/Interfaces/Command/CommandInfo.ts
+++ b/src/Infrastructure/Interfaces/Command/CommandInfo.ts
@@ -8,7 +8,6 @@ export interface CommandInfo {
 	usage: string;
 	group: string[];
 	roles: string[];
-	rolesDebitTickets: number;
-	unlimitedRoles: string[];
-	unlimitedRolesDebitTickets: number;
+	commandsPerSecond: number;
+	commandSurgeMax: number;
 }

--- a/src/Infrastructure/Interfaces/Command/CommandInfo.ts
+++ b/src/Infrastructure/Interfaces/Command/CommandInfo.ts
@@ -8,6 +8,6 @@ export interface CommandInfo {
 	usage: string;
 	group: string[];
 	roles: string[];
-	commandsPerSecond: number;
+	commandsPerMinute: number;
 	commandSurgeMax: number;
 }

--- a/src/Infrastructure/System/Command.ts
+++ b/src/Infrastructure/System/Command.ts
@@ -20,15 +20,14 @@ export abstract class Command<T extends Protomolecule = Protomolecule> {
 
 	public roles!: string[];
 
-	public rolesDebitTickets!: number;
+	public commandsPerSecond!: number;
 
-	public unlimitedRoles!: string[];
-
-	public unlimitedRolesDebitTickets!: number;
+	public commandSurgeMax!: number;
 
 	public constructor(info?: CommandInfo) {
-		if (info)
+		if (info) {
 			Object.assign(this, info);
+		}
 	}
 
 	public init(client: T): Command {

--- a/src/Infrastructure/System/Command.ts
+++ b/src/Infrastructure/System/Command.ts
@@ -20,7 +20,7 @@ export abstract class Command<T extends Protomolecule = Protomolecule> {
 
 	public roles!: string[];
 
-	public commandsPerSecond!: number;
+	public commandsPerMinute!: number;
 
 	public commandSurgeMax!: number;
 

--- a/src/Infrastructure/System/Configuration.ts
+++ b/src/Infrastructure/System/Configuration.ts
@@ -8,6 +8,7 @@ export default class Configuration {
 	public readonly statusType: string;
 	public readonly statusText: string;
 	public readonly welcomeChannels: Record<string, string>;
+	public readonly unlimitedRoles: string[];
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public constructor(
@@ -17,14 +18,16 @@ export default class Configuration {
 			owner,
 			commandPrefix,
 			statusType,
-			statusText
+			statusText,
+			unlimitedRoles
 		}:
 		{
 			welcomeChannels: Record<string, string>,
 			token: string, owner: string,
 			commandPrefix: string,
 			statusType: string,
-			statusText: string
+			statusText: string,
+			unlimitedRoles: string[]
 		}
 	) {
 		this.token = Configuration.ensureNonNull(token, 'token');
@@ -33,6 +36,7 @@ export default class Configuration {
 		this.statusType = Configuration.ensureNonNull(statusType, 'statusType');
 		this.statusText = Configuration.ensureNonNull(statusText, 'statusText');
 		this.welcomeChannels = welcomeChannels;
+		this.unlimitedRoles = unlimitedRoles;
 	}
 
 	private static ensureNonNull(value: string, key: string) : string {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,0 +1,3 @@
+import { infect } from './index';
+
+infect();


### PR DESCRIPTION
Change to the less opaque "commandsPerSecond" and "commandSurgeMax"
values for commands, allowing for more configurability on frequency
of different commands.

Get rid of configurability of unlimited command execution on a per
command basis. I don't _think_ that will ever come up but if we
need to we can bring it back. Also we don't need to configure that
unlimited means '0' tickets used. That seems like a universal
constant.

Also added the Avasarala command.